### PR TITLE
create a unique hash per query

### DIFF
--- a/impala_monitor/logger/logger.py
+++ b/impala_monitor/logger/logger.py
@@ -34,7 +34,8 @@ class ElasticFactory(object):
                     "memory_allocated": {"type": "float"},
                     "vcores_allocated": {"type": "integer"},
                     "exception_message": {"type": "string"},
-                    "exec_summary": {"type": "string"}
+                    "exec_summary": {"type": "string"},
+                    "query_hash": {"type": "string"}
                 }
             }
         }

--- a/impala_monitor/logger/parser.py
+++ b/impala_monitor/logger/parser.py
@@ -1,4 +1,6 @@
 import re
+import hashlib
+
 from bs4 import BeautifulSoup
 from datetime import datetime, timedelta
 
@@ -95,6 +97,10 @@ class ImpalaQueryLogParser(object):
                 cells[9].find('a', href=True).get('href')
             )
 
+            query = cells[2].get_text()
+            # create a unique hash per query to find duplicates.
+            query_hash = hashlib.sha256(b'{query}'.format(query=query))
+
             queries.append(Query({
                 'query': cells[2].get_text(),
                 'query_type': query_type,
@@ -106,6 +112,7 @@ class ImpalaQueryLogParser(object):
                 'execution_time': execution_time,
                 'query_id': query_id,
                 'timestamp': int(start_time.timestamp()),
+                'query_hash': query_hash.hexdigest()
             }))
 
         return queries


### PR DESCRIPTION
We had an issue with a query executed more than 30 times in a less than a second. To have more visibility of this kind of issue we have to store a unique hash per query, this will help us to find duplicates. The same string will generate always the same hash.

Later on, we can create a process to check if we have any query being executed many times without a reason.